### PR TITLE
add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/* linguist-generated=true


### PR DESCRIPTION
trying to hide the `dist/*` files in diffs.

However, we should make sure that people do generate them!