### PR TITLE
Don't post to the download cache when environment caching

### DIFF
--- a/.github/workflows/test_caching.yml
+++ b/.github/workflows/test_caching.yml
@@ -25,6 +25,8 @@ jobs:
         uses: ./
         with:
           cache-downloads: true
+          cache-downloads-key: download-downloadkey-${{ github.sha }}-${{ github.run_attempt }}
+
 
       - name: test environment name
         run: |
@@ -45,6 +47,7 @@ jobs:
         uses: ./
         with:
           cache-downloads: true
+          cache-downloads-key: download-downloadkey-${{ github.sha }}-${{ github.run_attempt }}
 
       - name: test environment name
         run: |
@@ -64,6 +67,7 @@ jobs:
         uses: ./
         with:
           cache-env: true
+          cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
 
       - name: test environment name
         run: |
@@ -84,6 +88,7 @@ jobs:
         uses: ./
         with:
           cache-env: true
+          cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
 
       - name: test environment name
         run: |
@@ -106,6 +111,52 @@ jobs:
         with:
           cache-env: true
           cache-env-always-update: true
+          cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
+
+      - name: test environment name
+        run: |
+          python -c "import os; env = os.path.basename(os.environ['CONDA_PREFIX']); assert env == 'testenv'"
+
+  test_download_and_env1:
+    name: Test download+env cache 1/2
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install mamba
+        uses: ./
+        with:
+          cache-downloads: true
+          cache-env: true
+          cache-downloads-key: download-env-downloadkey-${{ github.sha }}-${{ github.run_attempt }}
+          cache-env-key: download-env-envkey-${{ github.sha }}-${{ github.run_attempt }}
+
+      - name: test environment name
+        run: |
+          python -c "import os; env = os.path.basename(os.environ['CONDA_PREFIX']); assert env == 'testenv'"
+
+  test_download_and_env2:
+    name: Test download+env cache 2/2
+    needs: [test_download_and_env1]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install mamba
+        uses: ./
+        with:
+          cache-downloads: true
+          cache-env: true
+          cache-downloads-key: download-env-downloadkey-${{ github.sha }}-${{ github.run_attempt }}
+          cache-env-key: download-env-envkey-${{ github.sha }}-${{ github.run_attempt }}
 
       - name: test environment name
         run: |

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -315,7 +315,7 @@ Write-Host "Profile already exists and new content added"
     core.info(`Contents of ${PATHS.bashprofile}:\n${fs.readFileSync(PATHS.bashprofile)}`)
 
     // Save cache on workflow success
-    if (inputs.cacheDownloads && !downloadCacheHit) {
+    if ( ( !envCacheHit || inputs.cacheEnvAlwaysUpdate ) && inputs.cacheDownloads && !downloadCacheHit ) {
       saveCacheOnPost(...downloadCacheArgs)
     }
     if (inputs.cacheEnv && !envCacheHit) {

--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ Write-Host "Profile already exists and new content added"
     core.info(`Contents of ${PATHS.bashprofile}:\n${fs.readFileSync(PATHS.bashprofile)}`)
 
     // Save cache on workflow success
-    if (inputs.cacheDownloads && !downloadCacheHit) {
+    if ( ( !envCacheHit || inputs.cacheEnvAlwaysUpdate ) && inputs.cacheDownloads && !downloadCacheHit ) {
       saveCacheOnPost(...downloadCacheArgs)
     }
     if (inputs.cacheEnv && !envCacheHit) {


### PR DESCRIPTION
There appears to be a problem when one uses both the download cache and the environment cache. In particular, when the environment cache is hit, the current version still tries to post to the download cache, which fails because it's not set up (and shouldn't be run). The faulty logic appears to be here:

https://github.com/mamba-org/provision-with-micromamba/blob/5fe88d370c741fc3567126d17c5af0b9620bd60d/index.js#L305-L308

which is inconsistent with where `downloadCacheArgs` is defined here:

https://github.com/mamba-org/provision-with-micromamba/blob/5fe88d370c741fc3567126d17c5af0b9620bd60d/index.js#L275-L281

leading to an error that `downloadCacheArgs` is not iterable.

This PR fixes this by making the logic used to decide whether to post to the download cache consistent with the earlier logic on whether or not to use/setup the download cache.

I also added a test. In doing that, I noticed that the way the other cache tests were written, both jobs in the test would use an earlier cache version because the cache already exists for the job that's supposed to setup the cache (when running on the same day, the default cache-key is the same). So I created a custom key that incorporates the `github.ref` and the attempt number, which I think should uniquely determine a workflow run. Now the first job in the sequence always creates a new cache that is then used by the second job.

