### PR TITLE
Do not ignore PowerShell exit codes

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -64,7 +64,7 @@ function executeBash (command) {
 }
 
 function executePwsh (command) {
-  return executeShell('powershell', '-command', command)
+  return executeShell('powershell', '-command', `${command}; exit $LASTEXITCODE`)
 }
 
 function sha256 (s) {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function executeBash (command) {
 }
 
 function executePwsh (command) {
-  return executeShell('powershell', '-command', command)
+  return executeShell('powershell', '-command', `${command}; exit $LASTEXITCODE`)
 }
 
 function sha256 (s) {


### PR DESCRIPTION
@wolfv not sure why this is neccessary but without it (sometimes?) the `powershell -command` invocation doesn't fail if the command fails.